### PR TITLE
Fix menu bar icon toggle and update outdated references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1><img src="https://raw.github.com/citadelgrad/ShiftIt/master/artwork/ShiftIt.png" width="72" height="72" valign="middle"/>ShiftIt</h1>
+<h1><img src="https://raw.githubusercontent.com/citadelgrad/ShiftIt/master/artwork/ShiftIt.png" width="72" height="72" valign="middle"/>ShiftIt</h1>
 
 *Managing window size and position in macOS*
 
@@ -35,7 +35,7 @@ A binary build for macOS 14.6+ is available in [releases](https://github.com/cit
 
 ShiftIt installs itself in the menu bar (optionally it can be completely hidden). It provides a set of actions that manipulate window positions and sizes.
 
-![Screenshot Menu](https://raw.github.com/citadelgrad/ShiftIt/master/docs/schreenshot-menu.png)
+![Screenshot Menu](https://raw.githubusercontent.com/citadelgrad/ShiftIt/master/docs/schreenshot-menu.png)
 
 ### Available Actions
 

--- a/ShiftIt/AXWindowDriver.h
+++ b/ShiftIt/AXWindowDriver.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/AXWindowDriver.m
+++ b/ShiftIt/AXWindowDriver.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/DefaultShiftItActions.h
+++ b/ShiftIt/DefaultShiftItActions.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/DefaultShiftItActions.m
+++ b/ShiftIt/DefaultShiftItActions.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/FMT Tests/FMTGeometryTests.m
+++ b/ShiftIt/FMT Tests/FMTGeometryTests.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMT.h
+++ b/ShiftIt/FMT/FMT.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTDefines.h
+++ b/ShiftIt/FMT/FMTDefines.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTHotKey+SRKeyCombo.h
+++ b/ShiftIt/FMT/FMTHotKey+SRKeyCombo.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTHotKey+SRKeyCombo.m
+++ b/ShiftIt/FMT/FMTHotKey+SRKeyCombo.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTHotKey.h
+++ b/ShiftIt/FMT/FMTHotKey.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTHotKey.m
+++ b/ShiftIt/FMT/FMTHotKey.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTHotKeyManager.h
+++ b/ShiftIt/FMT/FMTHotKeyManager.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTHotKeyManager.m
+++ b/ShiftIt/FMT/FMTHotKeyManager.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTLoginItems.h
+++ b/ShiftIt/FMT/FMTLoginItems.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTLoginItems.m
+++ b/ShiftIt/FMT/FMTLoginItems.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSArray+Functional.h
+++ b/ShiftIt/FMT/FMTNSArray+Functional.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSArray+Functional.m
+++ b/ShiftIt/FMT/FMTNSArray+Functional.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSDate+Extras.h
+++ b/ShiftIt/FMT/FMTNSDate+Extras.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSDate+Extras.m
+++ b/ShiftIt/FMT/FMTNSDate+Extras.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSDictionary+Extras.h
+++ b/ShiftIt/FMT/FMTNSDictionary+Extras.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSDictionary+Extras.m
+++ b/ShiftIt/FMT/FMTNSDictionary+Extras.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSError+Extras.h
+++ b/ShiftIt/FMT/FMTNSError+Extras.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTNSError+Extras.m
+++ b/ShiftIt/FMT/FMTNSError+Extras.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTUtils.h
+++ b/ShiftIt/FMT/FMTUtils.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMT/FMTUtils.m
+++ b/ShiftIt/FMT/FMTUtils.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMTGeometry.h
+++ b/ShiftIt/FMTGeometry.h
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/FMTGeometry.m
+++ b/ShiftIt/FMTGeometry.m
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/ShiftIt/PreferencesWindowController.h
+++ b/ShiftIt/PreferencesWindowController.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/PreferencesWindowController.m
+++ b/ShiftIt/PreferencesWindowController.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/PreferencesWindowController.m
+++ b/ShiftIt/PreferencesWindowController.m
@@ -49,7 +49,7 @@ NSString *const kActionIdentifierKey = @"kActionIdentifierKey";
 NSString *const kHotKeyKeyCodeKey = @"kHotKeyKeyCodeKey";
 NSString *const kHotKeyModifiersKey = @"kHotKeyModifiersKey";
 
-NSString *const kShiftItGithubIssueURL = @"https://github.com/fikovnik/ShiftIt/issues";
+NSString *const kShiftItGithubIssueURL = @"https://github.com/citadelgrad/ShiftIt/issues";
 
 NSString *const kHotKeysTabViewItemIdentifier = @"hotKeys";
 

--- a/ShiftIt/SIActionDelegate.h
+++ b/ShiftIt/SIActionDelegate.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIAdjacentRectangles.h
+++ b/ShiftIt/SIAdjacentRectangles.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIAdjacentRectangles.m
+++ b/ShiftIt/SIAdjacentRectangles.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIDefines.h
+++ b/ShiftIt/SIDefines.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIScreen.h
+++ b/ShiftIt/SIScreen.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIScreen.m
+++ b/ShiftIt/SIScreen.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIWindow.h
+++ b/ShiftIt/SIWindow.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIWindowContext.h
+++ b/ShiftIt/SIWindowContext.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIWindowDriver.h
+++ b/ShiftIt/SIWindowDriver.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIWindowInfo.h
+++ b/ShiftIt/SIWindowInfo.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIWindowManager.h
+++ b/ShiftIt/SIWindowManager.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/SIWindowManager.m
+++ b/ShiftIt/SIWindowManager.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/ShiftIt-Info.plist
+++ b/ShiftIt/ShiftIt-Info.plist
@@ -45,6 +45,6 @@
 	<key>SUEnableSystemProfiling</key>
 	<true/>
 	<key>SUFeedURL</key>
-	<string>https://raw.github.com/citadelgrad/ShiftIt/master/release/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/citadelgrad/ShiftIt/master/release/appcast.xml</string>
 </dict>
 </plist>

--- a/ShiftIt/ShiftIt.h
+++ b/ShiftIt/ShiftIt.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/ShiftIt.xcodeproj/PreferencesController.swift
+++ b/ShiftIt/ShiftIt.xcodeproj/PreferencesController.swift
@@ -469,7 +469,7 @@ struct AboutPreferencesView: View {
             
             // Credits
             VStack(spacing: 8) {
-                Text("Copyright © 2010-2025")
+                Text("Copyright © 2010-\(Calendar.current.component(.year, from: Date()))")
                     .font(.caption)
                     .foregroundColor(.secondary)
                 

--- a/ShiftIt/ShiftIt.xcodeproj/PreferencesController.swift
+++ b/ShiftIt/ShiftIt.xcodeproj/PreferencesController.swift
@@ -113,6 +113,9 @@ struct GeneralPreferencesView: View {
             Section {
                 Toggle("Show menu bar icon", isOn: $showMenuIcon)
                     .help("Display ShiftIt icon in the menu bar")
+                    .onChange(of: showMenuIcon) { _, _ in
+                        NotificationCenter.default.post(name: .menuBarIconPreferenceChanged, object: nil)
+                    }
                 
                 Toggle("Start at login", isOn: $shouldStartAtLogin)
                     .help("Launch ShiftIt automatically when you log in")
@@ -470,9 +473,9 @@ struct AboutPreferencesView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                 
-                Link("Visit Website", destination: URL(string: "https://github.com/fikovnik/ShiftIt")!)
-                
-                Link("Report an Issue", destination: URL(string: "https://github.com/fikovnik/ShiftIt/issues")!)
+                Link("Visit Website", destination: URL(string: "https://github.com/citadelgrad/ShiftIt")!)
+
+                Link("Report an Issue", destination: URL(string: "https://github.com/citadelgrad/ShiftIt/issues")!)
             }
             
             Spacer()

--- a/ShiftIt/ShiftIt.xcodeproj/ShiftItApp.swift
+++ b/ShiftIt/ShiftIt.xcodeproj/ShiftItApp.swift
@@ -148,6 +148,28 @@ class ShiftItApp: NSObject, NSApplicationDelegate {
             name: .showPreferencesRequest,
             object: nil
         )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMenuBarIconPreferenceChanged),
+            name: .menuBarIconPreferenceChanged,
+            object: nil
+        )
+    }
+
+    @objc private func handleMenuBarIconPreferenceChanged() {
+        let showMenuIcon = defaults.bool(forKey: UserDefaultsKeys.showMenuIcon)
+
+        if showMenuIcon {
+            if menuBarController == nil {
+                menuBarController = MenuBarController(
+                    windowManager: windowManager,
+                    statistics: statistics
+                )
+            }
+        } else {
+            menuBarController = nil
+        }
     }
     
     // MARK: - Accessibility Permission Handling
@@ -243,6 +265,7 @@ enum UserDefaultsKeys {
 
 extension Notification.Name {
     static let showPreferencesRequest = Notification.Name("org.shiftitapp.shiftit.notifications.showPreferences")
+    static let menuBarIconPreferenceChanged = Notification.Name("org.shiftitapp.shiftit.notifications.menuBarIconPreferenceChanged")
 }
 
 // MARK: - Usage Statistics

--- a/ShiftIt/ShiftIt.xcodeproj/project.pbxproj
+++ b/ShiftIt/ShiftIt.xcodeproj/project.pbxproj
@@ -755,7 +755,7 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "FMT Tests/FMT Tests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				PRODUCT_BUNDLE_IDENTIFIER = "net.fikovnik.projects.FMT.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.shiftitapp.FMT.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = octest;
 			};
@@ -777,7 +777,7 @@
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				INFOPLIST_FILE = "FMT Tests/FMT Tests-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				PRODUCT_BUNDLE_IDENTIFIER = "net.fikovnik.projects.FMT.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.shiftitapp.FMT.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = octest;
 			};

--- a/ShiftIt/ShiftItApp.h
+++ b/ShiftIt/ShiftItApp.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/ShiftItAppDelegate.h
+++ b/ShiftIt/ShiftItAppDelegate.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/ShiftItAppDelegate.m
+++ b/ShiftIt/ShiftItAppDelegate.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
  
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/WindowGeometryShiftItAction.h
+++ b/ShiftIt/WindowGeometryShiftItAction.h
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/ShiftIt/WindowGeometryShiftItAction.m
+++ b/ShiftIt/WindowGeometryShiftItAction.m
@@ -1,6 +1,6 @@
 /*
  ShiftIt: Window Organizer for OSX
- Copyright (c) 2010-2011 Filip Krikava
+ Copyright (c) 2010-2025 Filip Krikava
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/fabfile.py
+++ b/fabfile.py
@@ -229,7 +229,7 @@ proj_archive_name = proj_name + '-' + proj_version + '.zip'
 proj_archive_path = os.path.join(proj_build_dir, proj_archive_name)
 
 proj_download_url = 'https://github.com/citadelgrad/ShiftIt/releases/download/version-%s/%s' % (proj_version, proj_archive_name)
-proj_release_notes_url = 'http://htmlpreview.github.com/?https://raw.github.com/citadelgrad/ShiftIt/master/release/release-notes-'+proj_version+'.html'
+proj_release_notes_url = 'https://raw.githubusercontent.com/citadelgrad/ShiftIt/master/release/release-notes-'+proj_version+'.html'
 proj_release_notes_html_file = os.path.join(os.getcwd(),'release','release-notes-'+proj_version+'.html')
 proj_appcast_file = os.path.join(os.getcwd(),'release','appcast.xml')
 proj_github_token = _load_github_token()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "shiftit-tools"
 version = "0.1.0"
 description = "Build and release tools for ShiftIt"
-requires-python = ">=3.8.1"
+requires-python = ">=3.12"
 
 dependencies = [
     "asn1crypto>=1.0.0",

--- a/release/appcast.xml
+++ b/release/appcast.xml
@@ -2,12 +2,12 @@
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
    <channel>
       <title>ShiftIt Changelog</title>
-      <link>https://raw.github.com/citadelgrad/ShiftIt/master/release/appcast.xml</link>
+      <link>https://raw.githubusercontent.com/citadelgrad/ShiftIt/master/release/appcast.xml</link>
       <language>en</language>
       <item>
          <title>ShiftIt version 2.0.0</title>
          <sparkle:releaseNotesLink>
-            http://htmlpreview.github.com/?https://raw.github.com/citadelgrad/ShiftIt/master/release/release-notes-2.0.0.html
+            https://raw.githubusercontent.com/citadelgrad/ShiftIt/master/release/release-notes-2.0.0.html
          </sparkle:releaseNotesLink>
          <pubDate>Thu, 08 Jan 2026 00:43:14 +0000</pubDate>
          <enclosure

--- a/release/build-release.sh
+++ b/release/build-release.sh
@@ -69,12 +69,12 @@ cat > "$APPCAST_FILE" << EOF
 <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
    <channel>
       <title>ShiftIt Changelog</title>
-      <link>https://raw.github.com/${GITHUB_REPO}/master/release/appcast.xml</link>
+      <link>https://raw.githubusercontent.com/${GITHUB_REPO}/master/release/appcast.xml</link>
       <language>en</language>
       <item>
          <title>ShiftIt version ${VERSION}</title>
          <sparkle:releaseNotesLink>
-            http://htmlpreview.github.com/?https://raw.github.com/${GITHUB_REPO}/master/release/release-notes-${VERSION}.html
+            https://raw.githubusercontent.com/${GITHUB_REPO}/master/release/release-notes-${VERSION}.html
          </sparkle:releaseNotesLink>
          <pubDate>${PUB_DATE}</pubDate>
          <enclosure


### PR DESCRIPTION
## Summary
- Fix "Show Icon In Menu Bar" preference to respond at runtime by observing preference changes and creating/destroying the MenuBarController
- Update "Report an Issue" and "Visit Website" links from fikovnik/ShiftIt to citadelgrad/ShiftIt
- Replace deprecated `raw.github.com` URLs with `raw.githubusercontent.com`
- Remove dead `htmlpreview.github.com` links
- Update test bundle identifier from `net.fikovnik` to `org.shiftitapp`
- Update copyright years across all legacy source files
- Make About view copyright year dynamic

Fixes #3

## Test plan
- [x] Toggle "Show menu bar icon" off — icon should disappear from menu bar
- [x] Toggle it back on — icon should reappear
- [x] Click "Report an Issue" in About tab — should open citadelgrad/ShiftIt/issues
- [x] Verify CI build passes